### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 
 = Config Server sample
 
-*Cook* is an example application demonstrating the use of Config Server for Pivotal Cloud Foundry. (For information on the Config Server product, please http://docs.pivotal.io/spring-cloud-services/config-server/[see the documentation].)
+*Cook* is an example application demonstrating the use of Config Server for Pivotal Cloud Foundry. (For information on the Config Server product, please https://docs.pivotal.io/spring-cloud-services/config-server/[see the documentation].)
 
 == Building and Deploying
 
@@ -30,7 +30,7 @@ image::manage-config-server.png[link:docs/images/manage-config-server.png]
 
 . Save your settings and let the script continue. It will push the application and bind the Config Server instance.
 
-. When the script has finished, set the `CF_TARGET` environment variable to the API endpoint of your Elastic Runtime instance (as in `https://api.example.com`), then run `cf restage cook` to restage the application so that that change will take effect. Setting `CF_TARGET` causes Spring Cloud Services to add the the SSL certificate at the specfied API endpoint to the JVM's truststore, so that the client application can talk to a Config Server service instance even if your Elastic Runtime instance is using a self-signed SSL certificate (see the http://docs.pivotal.io/spring-cloud-services/config-server/writing-a-spring-client.html#self-signed-ssl-certificate[Config Server documentation]).
+. When the script has finished, set the `CF_TARGET` environment variable to the API endpoint of your Elastic Runtime instance (as in `https://api.example.com`), then run `cf restage cook` to restage the application so that that change will take effect. Setting `CF_TARGET` causes Spring Cloud Services to add the the SSL certificate at the specfied API endpoint to the JVM's truststore, so that the client application can talk to a Config Server service instance even if your Elastic Runtime instance is using a self-signed SSL certificate (see the https://docs.pivotal.io/spring-cloud-services/config-server/writing-a-spring-client.html#self-signed-ssl-certificate[Config Server documentation]).
 +
 ....
 $ cf set-env cook CF_TARGET https://api.wise.com
@@ -42,7 +42,7 @@ $ cf restage cook
 +
 [NOTE]
 ====
-By default, the Config Server client dependency will cause all application endpoints to be secured by HTTP Basic authentication. For more information or if you wish to disable this, http://scs-docs.black.springapps.io/spring-cloud-services/config-server/writing-a-spring-client.html#disable-http-basic-auth[see the documentation]. (HTTP Basic authentication is disabled in this sample application.)
+By default, the Config Server client dependency will cause all application endpoints to be secured by HTTP Basic authentication. For more information or if you wish to disable this, https://scs-docs.black.springapps.io/spring-cloud-services/config-server/writing-a-spring-client.html#disable-http-basic-auth[see the documentation]. (HTTP Basic authentication is disabled in this sample application.)
 ====
 
 == Trying It Out


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://scs-docs.black.springapps.io/spring-cloud-services/config-server/writing-a-spring-client.html (UnknownHostException) with 1 occurrences migrated to:  
  https://scs-docs.black.springapps.io/spring-cloud-services/config-server/writing-a-spring-client.html ([https](https://scs-docs.black.springapps.io/spring-cloud-services/config-server/writing-a-spring-client.html) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.pivotal.io/spring-cloud-services/config-server/ with 1 occurrences migrated to:  
  https://docs.pivotal.io/spring-cloud-services/config-server/ ([https](https://docs.pivotal.io/spring-cloud-services/config-server/) result 301).
* [ ] http://docs.pivotal.io/spring-cloud-services/config-server/writing-a-spring-client.html with 1 occurrences migrated to:  
  https://docs.pivotal.io/spring-cloud-services/config-server/writing-a-spring-client.html ([https](https://docs.pivotal.io/spring-cloud-services/config-server/writing-a-spring-client.html) result 301).