### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 
 = Config Server sample
 
-*Cook* is an example application demonstrating the use of Config Server for Pivotal Cloud Foundry. (For information on the Config Server product, please http://docs.pivotal.io/spring-cloud-services/config-server/[see the documentation].)
+*Cook* is an example application demonstrating the use of Config Server for Pivotal Cloud Foundry. (For information on the Config Server product, please https://docs.pivotal.io/spring-cloud-services/config-server/[see the documentation].)
 
 == Building and Deploying
 
@@ -26,7 +26,7 @@ $ ./scripts/deploy.sh target/cook-0.0.1-SNAPSHOT.jar
 +
 The script will create a Config Server service instance, push the application, and bind the Config Server service instance to the application.
 
-. When the script has finished, set the `CF_TARGET` environment variable to the API endpoint of your Elastic Runtime instance (as in `https://api.example.com`), then run `cf restage cook` to restage the application so that that change will take effect. Setting `CF_TARGET` causes Spring Cloud Services to add the the SSL certificate at the specfied API endpoint to the JVM's truststore, so that the client application can communicate with a Config Server service instance even if your Elastic Runtime instance is using a self-signed SSL certificate (see the http://docs.pivotal.io/spring-cloud-services/config-server/writing-client-applications.html#disable-http-basic-auth[Config Server documentation]).
+. When the script has finished, set the `CF_TARGET` environment variable to the API endpoint of your Elastic Runtime instance (as in `https://api.example.com`), then run `cf restage cook` to restage the application so that that change will take effect. Setting `CF_TARGET` causes Spring Cloud Services to add the the SSL certificate at the specfied API endpoint to the JVM's truststore, so that the client application can communicate with a Config Server service instance even if your Elastic Runtime instance is using a self-signed SSL certificate (see the https://docs.pivotal.io/spring-cloud-services/config-server/writing-client-applications.html#disable-http-basic-auth[Config Server documentation]).
 +
 ....
 $ cf set-env cook CF_TARGET https://api.wise.com
@@ -38,7 +38,7 @@ $ cf restage cook
 +
 [NOTE]
 ====
-By default, the Config Server client dependency will cause all application endpoints to be secured by HTTP Basic authentication. For more information or if you wish to disable this, http://docs.pivotal.io/spring-cloud-services/config-server/writing-client-applications.html#disable-http-basic-auth[see the documentation]. (HTTP Basic authentication is disabled in this sample application.)
+By default, the Config Server client dependency will cause all application endpoints to be secured by HTTP Basic authentication. For more information or if you wish to disable this, https://docs.pivotal.io/spring-cloud-services/config-server/writing-client-applications.html#disable-http-basic-auth[see the documentation]. (HTTP Basic authentication is disabled in this sample application.)
 ====
 
 == Trying It Out


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.pivotal.io/spring-cloud-services/config-server/ with 1 occurrences migrated to:  
  https://docs.pivotal.io/spring-cloud-services/config-server/ ([https](https://docs.pivotal.io/spring-cloud-services/config-server/) result 301).
* [ ] http://docs.pivotal.io/spring-cloud-services/config-server/writing-client-applications.html with 2 occurrences migrated to:  
  https://docs.pivotal.io/spring-cloud-services/config-server/writing-client-applications.html ([https](https://docs.pivotal.io/spring-cloud-services/config-server/writing-client-applications.html) result 301).