### PR TITLE
Determine CS service name from marketplace.

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,7 @@ then
   exit 1
 fi
 
-if [ ! -z "`cf m | grep "p.config-server"`" ]; then
+if [ ! -z "`cf m | grep "p\.config-server"`" ]; then
   export service_name="p.config-server"
 elif [ ! -z "`cf m | grep "p-config-server"`" ]; then
   export service_name="p-config-server"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,9 +4,19 @@ then
   echo "Please provide the path to the application archive."
   exit 1
 fi
+
+if [ ! -z "`cf m | grep "p.config-server"`" ]; then
+  export service_name="p.config-server"
+elif [ ! -z "`cf m | grep "p-config-server"`" ]; then
+  export service_name="p-config-server"
+else
+  echo "Can't find SCS Config Server in marketplace. Have you installed the SCS Tile?"
+  exit 1;
+fi
+
 echo -n "Creating Config Server..."
 {
-  cf create-service -c '{ "git": { "uri": "https://github.com/spring-cloud-services-samples/cook-config", "label": "master"  } }' p-config-server standard cook-config-server
+  cf create-service -c '{ "git": { "uri": "https://github.com/spring-cloud-services-samples/cook-config", "label": "master"  } }' ${service_name} standard cook-config-server
 } &> /dev/null
 until [ `cf service cook-config-server | grep -c "succeeded"` -eq 1  ]
 do


### PR DESCRIPTION
Tries to determine the config server service name based on what it finds in the marketplace (e.g., `cf m`). This makes the deploy script more flexible to work with either SCS 2 or SCS3 (with a preference for SCS 3's config server if both tiles are installed), and fail fast if it can't find either in the marketplace.

This change is only for the Unix shell script; I'm not well-versed enough to know how to write Windows batch to achieve the same thing, nor do I have Windows installed so that I could test it. That said, perhaps instead of Windows batch, this could be rewritten as Powershell, which is installable on Mac. If it were Powershell, I might be able to figure out how to support Windows in this change.