### PR TITLE
Upgrade scs starters to v3.0.1.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id "org.springframework.boot" version "2.1.4.RELEASE"
+	id "org.springframework.boot" version "2.1.10.RELEASE"
 }
 
 version = "0.0.1-SNAPSHOT"
@@ -19,8 +19,8 @@ jar {
 dependencyManagement {
 	imports {
 		mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:Greenwich.SR1"
-		mavenBom "io.pivotal.spring.cloud:spring-cloud-services-dependencies:2.1.2.RELEASE"
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:Greenwich.SR4"
+		mavenBom "io.pivotal.spring.cloud:spring-cloud-services-dependencies:3.0.1.RELEASE"
 	}
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/pom.xml
+++ b/pom.xml
@@ -14,15 +14,15 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
+		<version>2.1.10.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Greenwich.SR1</spring-cloud.version>
-		<spring-cloud-services.version>2.1.2.RELEASE</spring-cloud-services.version>
+		<spring-cloud.version>Greenwich.SR4</spring-cloud.version>
+		<spring-cloud-services.version>3.0.1.RELEASE</spring-cloud-services.version>
 	</properties>
 
 	<dependencyManagement>

--- a/src/main/java/cook/DessertMenu.java
+++ b/src/main/java/cook/DessertMenu.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 
-import io.pivotal.spring.cloud.service.config.PlainTextConfigClient;
+import io.pivotal.spring.cloud.config.client.PlainTextConfigClient;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/src/test/java/cook/DessertMenuTest.java
+++ b/src/test/java/cook/DessertMenuTest.java
@@ -19,13 +19,12 @@ package cook;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
 
+import io.pivotal.spring.cloud.config.client.PlainTextConfigClient;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import io.pivotal.spring.cloud.service.config.PlainTextConfigClient;
 
 import org.springframework.core.io.InputStreamResource;
 


### PR DESCRIPTION
 - upgrade starters to v3.0.1.RELEASE
 - upgrade spring-boot to v2.1.10.RELEASE
 - upgrade spring-cloud to Greenwich.SR4
 - update package name of moved class
Connected to pivotal-cf/spring-cloud-services-starters#119