### PR TITLE
move application name to the top

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 ---
 spring:
-  config:
-    import: "optional:configserver:"
   application:
     name: cook
+  config:
+    import: "optional:configserver:"
 
 encrypt:
   keyStore:


### PR DESCRIPTION
this fixes a broken link in SCS docs.

Signed-off-by: kvmw <mshamsi@broadcom.com>
